### PR TITLE
Updated Readme for Get the Series example

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -21,7 +21,7 @@ search for your series
 <code>results = tvdb.search('the west wing')</code>
 
 get the series
-<code>west_wing = tvdb.get_series_by_id(results["seriesid"])</code>
+<code>west_wing = tvdb.get_series_by_id(results.first["seriesid"])</code>
 <code>puts west_wing.name</code>
 => The West Wing
 


### PR DESCRIPTION
I changed the example for "get the series" to include results.first["seriesid"].  This avoids the Error TypeError: can't convert String into Integer when using get_series_by_id.
