### PR TITLE
Fixed missing first character in episode's 1st guest star

### DIFF
--- a/lib/tvdb_party/episode.rb
+++ b/lib/tvdb_party/episode.rb
@@ -2,7 +2,7 @@ module TvdbParty
   class Episode
     attr_reader :client
     attr_accessor :id, :season_number, :number, :name, :overview, :air_date, :thumb, :guest_stars, :director, :writer
-    
+
     def initialize(client, options={})
       @client = client
       @id = options["id"]
@@ -15,18 +15,18 @@ module TvdbParty
       @writer = options["Writer"]
       @series_id = options["seriesid"]
       if options["GuestStars"]
-        @guest_stars = options["GuestStars"][1..-1].split("|")
+        @guest_stars = options["GuestStars"].split("|").reject(&:empty?)
       else
         @guest_stars = []
       end
 
-      begin 
+      begin
         @air_date = Date.parse(options["FirstAired"])
       rescue
         puts 'invalid date'
       end
     end
-    
+
     def series
       client.get_series_by_id(@series_id)
     end

--- a/lib/tvdb_party/series.rb
+++ b/lib/tvdb_party/series.rb
@@ -15,7 +15,7 @@ module TvdbParty
       @imdb_id = options["IMDB_ID"]
 
       if options["Genre"]
-        @genres = options["Genre"][1..-1].split("|")
+        @genres = options["Genre"].split("|").reject(&:empty?)
       else
         @genres = []
       end


### PR DESCRIPTION
This is a fix for guest stars having their initial letter chopped off.

Splitting on the pipe character in guest stars and genres seems to bank on the fact that the TVDB API will always start a list with the pipe character. This is not (no longer?) always the case though. I've replaced the slices with rejects so it doesn't matter if the string starts with a pipe.
