### PR TITLE
removed error printouts. added to_hash methods

### DIFF
--- a/lib/tvdb_party/episode.rb
+++ b/lib/tvdb_party/episode.rb
@@ -36,12 +36,23 @@ module TvdbParty
       begin 
         @air_date = Date.parse(options["FirstAired"])
       rescue
-        puts 'invalid date'
       end
     end
     
     def series
       client.get_series_by_id(@series_id)
     end
+
+    def to_h
+      hash = {}
+      self.instance_variables.each do | var |
+          #turn episode object into hash
+          v = self.instance_variable_get( var )
+          hash[ var.to_s.gsub('@','').to_sym ] = v
+      end
+      hash.delete(:client)
+      return hash
+    end
+
   end
 end

--- a/lib/tvdb_party/series.rb
+++ b/lib/tvdb_party/series.rb
@@ -92,6 +92,7 @@ module TvdbParty
           hash[ var.to_s.gsub('@','').to_sym ] = v
       end
       hash.delete(:client)
+      hash.delete(:banners)
       return hash
     end
 

--- a/lib/tvdb_party/series.rb
+++ b/lib/tvdb_party/series.rb
@@ -37,7 +37,6 @@ module TvdbParty
       begin
         @first_aired = Date.parse(options["FirstAired"])
       rescue
-        puts 'invalid date'
       end
     end
 
@@ -83,6 +82,17 @@ module TvdbParty
 
     def season(season_number)
       seasons.detect{|s| s.number == season_number}
+    end
+
+    def to_h
+      hash = {}
+      self.instance_variables.each do | var |
+          #turn episode object into hash
+          v = self.instance_variable_get( var )
+          hash[ var.to_s.gsub('@','').to_sym ] = v
+      end
+      hash.delete(:client)
+      return hash
     end
 
   end

--- a/tvdb_party.gemspec
+++ b/tvdb_party.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "tvdb_party"
-  s.version = "0.8.0"
+  s.version = "0.8.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]


### PR DESCRIPTION
Hi,

Great gem!

I have a command line tool that uses http_party under the hood and outputs some JSON.  the 'invalid date' error messages in episode  and series were causing my stdout to be invalid as they mixed in with the JSON.   would you be ok if we removed them?

I also added to_hash methods to make it easier to convert the objects to JSON.

Finally, on rubygems.org tvdb_party is at 0.8.1 but I could only find 0.8.0 on your github page.  Did I fork from the wrong place?  Let me know and I'll redo the pull request.

Thanks!

-poul